### PR TITLE
feat(intercon): Add axi interconnect hardware.mk

### DIFF
--- a/hardware/axiinterconnect/hardware.mk
+++ b/hardware/axiinterconnect/hardware.mk
@@ -1,0 +1,11 @@
+ifneq (axiinterconnect,$(filter axiinterconnect, $(HW_MODULES)))
+
+# Add to modules list
+HW_MODULES+=axiinterconnect
+
+# Sources
+VSRC+=$(AXI_DIR)/submodules/V_AXI/rtl/axi_interconnect.v
+VSRC+=$(AXI_DIR)/submodules/V_AXI/rtl/arbiter.v
+VSRC+=$(AXI_DIR)/submodules/V_AXI/rtl/priority_encoder.v
+
+endif


### PR DESCRIPTION
- Add `hardware.mk` to include sources for axi interconnect module
- This is used in systems that require testbenches where the SUT has
multiple AXI4 interfaces, usually one for the cache and another for a
core/peripheral DMA