### PR TITLE
fix(python): Fix python script shebang

### DIFF
--- a/software/axi_gen.py
+++ b/software/axi_gen.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 #
 # type = [master|slave]_[port|portmap|wire|tb] or [master|slave]_[write|read]_[port|portmap|wire|tb]


### PR DESCRIPTION
Fix python script shebang to use `/usr/bin/env` interpreter instead
of system interpreter.
This uses the first python3 interpreter in `$PATH` instead of the
hardcoded `/usr/bin/python3` system interpreter. This change is needed
if we want to run the python scripts from a virtual environment for
example.
- Check: [this post](https://unix.stackexchange.com/questions/29608/why-is-it-better-to-use-usr-bin-env-name-instead-of-path-to-name-as-my/29620#29620) for more information